### PR TITLE
Add groovy support

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,8 +55,14 @@ function updateTextVisibility(editor: vscode.TextEditor, isActive: boolean, hide
                     decorationsArray.push({ range });
                 }
             } else if (languageId === 'python') {
-                // Hides lines containing Python or Groovy print statements
+                // Hides lines containing Python print statements
                 if (text.match(/\bprint\(/)) {
+                    const range = new vscode.Range(i, 0, i, line.text.length);
+                    decorationsArray.push({ range });
+                }
+                // Hides lines containing Groovy print statements
+            } else if (languageId === 'groovy') {
+                if (text.match(/\b(print(ln|f)?|System\.out\.print(ln|f)?)\(/)) {
                     const range = new vscode.Range(i, 0, i, line.text.length);
                     decorationsArray.push({ range });
                 }
@@ -87,14 +93,6 @@ function updateTextVisibility(editor: vscode.TextEditor, isActive: boolean, hide
                 }
             }
             
-            // Handle AL single-line comments
-            if (languageId === 'groovy') {
-                if (text.match(/\b(print(ln|f)?|System\.out\.print(ln|f)?)\(/)) {
-                    const range = new vscode.Range(i, 0, i, line.text.length);
-                    decorationsArray.push({ range });
-                }
-            }
-
             if (!validLanguage) {
               vscode.window.showInformationMessage("Language not supported");
               break;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,7 +54,7 @@ function updateTextVisibility(editor: vscode.TextEditor, isActive: boolean, hide
                     const range = new vscode.Range(i, 0, i, line.text.length);
                     decorationsArray.push({ range });
                 }
-            } else if (languageId === 'python' || languageId === 'groovy') {
+            } else if (languageId === 'python') {
                 // Hides lines containing Python or Groovy print statements
                 if (text.match(/\bprint\(/)) {
                     const range = new vscode.Range(i, 0, i, line.text.length);
@@ -87,6 +87,14 @@ function updateTextVisibility(editor: vscode.TextEditor, isActive: boolean, hide
                 }
             }
             
+            // Handle AL single-line comments
+            if (languageId === 'groovy') {
+                if (text.match(/\b(print(ln|f)?|System\.out\.print(ln|f)?)\(/)) {
+                    const range = new vscode.Range(i, 0, i, line.text.length);
+                    decorationsArray.push({ range });
+                }
+            }
+
             if (!validLanguage) {
               vscode.window.showInformationMessage("Language not supported");
               break;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,6 +41,8 @@ function updateTextVisibility(editor: vscode.TextEditor, isActive: boolean, hide
                 validLanguage = true;
               case "al":
                 validLanguage = true;
+            case "groovy":
+                validLanguage = true;    
               default:
                 break;
             }
@@ -52,8 +54,8 @@ function updateTextVisibility(editor: vscode.TextEditor, isActive: boolean, hide
                     const range = new vscode.Range(i, 0, i, line.text.length);
                     decorationsArray.push({ range });
                 }
-            } else if (languageId === 'python') {
-                // Hides lines containing Python print statements
+            } else if (languageId === 'python' || languageId === 'groovy') {
+                // Hides lines containing Python or Groovy print statements
                 if (text.match(/\bprint\(/)) {
                     const range = new vscode.Range(i, 0, i, line.text.length);
                     decorationsArray.push({ range });
@@ -62,7 +64,7 @@ function updateTextVisibility(editor: vscode.TextEditor, isActive: boolean, hide
 
             // Hide comments, assuming single-line comments start with '//'
             const commentIndex = text.indexOf('//');
-            if (commentIndex !== -1 && (languageId === 'javascript' || languageId === 'typescript')) {
+            if (commentIndex !== -1 && (languageId === 'javascript' || languageId === 'typescript' || languageId === 'groovy')) {
                 const range = new vscode.Range(i, commentIndex, i, line.text.length);
                 decorationsArray.push({ range });
             }
@@ -84,7 +86,7 @@ function updateTextVisibility(editor: vscode.TextEditor, isActive: boolean, hide
                     decorationsArray.push({ range });
                 }
             }
-
+            
             if (!validLanguage) {
               vscode.window.showInformationMessage("Language not supported");
               break;


### PR DESCRIPTION
Minor change to support groovy: https://groovy-lang.org/syntax.html
I mainly use groovy for Jenkins pipelines. 


Single line comments are // thus fitting JavaScript/TypeScript.

Prints are as below:
print "Hello, World"
println "Hello, World"
printf "Hello, %s", "World"

Classic Java: 
System.out.print("Hello")
System.out.println("World")
System.out.printf("Value: %.2f", 3.14)

The matching should grab all of the above. 

